### PR TITLE
fix: JSON.parse error

### DIFF
--- a/lib/bodyParser/json.js
+++ b/lib/bodyParser/json.js
@@ -6,6 +6,6 @@
  */
 module.exports = {
   parse : function(data, callback) {
-    callback(JSON.parse(data));
+    callback(data ? JSON.parse(data) : '');
   }
 };


### PR DESCRIPTION
fix: When trying to parse no data, a syntax error is occurred. This should solve it.